### PR TITLE
hotfix remove proxy key

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,7 +34,6 @@ jobs:
           key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
           proxy_host: 3.35.14.92
           proxy_username: ubuntu
-          proxy_key: ${{ secrets.AWS_SSH_PRIVATE_KEY }}
 
           # 아래 내용을 실행하여 Docker 이미지를 내려받고 실행
           script: |


### PR DESCRIPTION
bastion host의 공개키를 frontend instance에 넣어두었으므로 proxy key가 불필요합니다.